### PR TITLE
Rewrite handle function for "Stop" Action

### DIFF
--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -31,12 +31,9 @@ handle(Data, Call) ->
 handle(Data, Call, <<"start">>) ->
     lager:debug("starting recording, see you on the other side"),
     kapps_call:start_recording(Data, Call);
-handle(Data, Call, <<"stop">> = Action) ->
-    Format = kzc_recording:get_format(kz_json:get_value(<<"format">>, Data)),
-    MediaName = kzc_recording:get_media_name(kapps_call:call_id(Call), Format),
-
-    _ = kapps_call_command:record_call([{<<"Media-Name">>, MediaName}], Action, Call),
-    lager:debug("sent command to stop recording"),
+handle(_Data, Call, <<"stop">>) ->
+    kapps_call:stop_recording(Call),
+    lager:debug("sent command to stop recording call"),
     Call.
 
 -spec get_action(kz_term:api_ne_binary()) -> kz_term:ne_binary().


### PR DESCRIPTION
Rewrite of handle function for "Stop" Action to fix Action not stopping recording where using different media name than "CallID.Format" as it invokes a hardcoded "CallID.Format" stop.

Used same functions as in Callflow app and launch function kapps_call:stop_recording() to invoke Stop command through kapps_call module instead of calling kapps_call_command:record_call directly. This to be able to stop the recording by name as saved in the custom_channel_variable for the media file name instead of invoking a stop on hardcoded CallID.Format.